### PR TITLE
ROSFlight GNSS compatibility

### DIFF
--- a/include/rosflight_plugins/GPS_plugin.h
+++ b/include/rosflight_plugins/GPS_plugin.h
@@ -74,7 +74,7 @@ namespace rosflight_plugins
 
     // Message with static info prefilled
     rosflight_msgs::GNSS GNSS_message_;
-    sensor_msgs::NavSatFix GNSS_fix_message_
+    sensor_msgs::NavSatFix GNSS_fix_message_;
     geometry_msgs::TwistStamped GNSS_vel_message_;
 
     // params
@@ -107,7 +107,7 @@ namespace rosflight_plugins
 
     void measure(double dpn, double dpe, double & dlat, double & dlon);
     inline double square(double a) {return a * a;}
-    inline double deg_to_rad(double deg) {return deg * M_PI / 180.0}
+    inline double deg_to_rad(double deg) {return deg * M_PI / 180.0;}
     double earth_radius(double latitude);
     void lla_to_ecef(double latitude, double longitude, double altitude, double &x, double &y, double &z);
 

--- a/include/rosflight_plugins/GPS_plugin.h
+++ b/include/rosflight_plugins/GPS_plugin.h
@@ -68,14 +68,14 @@ namespace rosflight_plugins
     std::normal_distribution<double> standard_normal_distribution_;
 
     // Topic
-    std::string GNSS_topic_;
-    std::string GNSS_vel_topic_;
-    std::string GNSS_fix_topic_;
+    std::string gnss_topic_;
+    std::string gnss_vel_topic_;
+    std::string gnss_fix_topic_;
 
     // Message with static info prefilled
-    rosflight_msgs::GNSS GNSS_message_;
-    sensor_msgs::NavSatFix GNSS_fix_message_;
-    geometry_msgs::TwistStamped GNSS_vel_message_;
+    rosflight_msgs::GNSS gnss_message_;
+    sensor_msgs::NavSatFix gnss_fix_message_;
+    geometry_msgs::TwistStamped gnss_vel_message_;
 
     // params
     double pub_rate_;
@@ -101,15 +101,8 @@ namespace rosflight_plugins
 
     double sample_time_;
 
-    //Constants, from Wikipedia https://en.wikipedia.org/wiki/World_Geodetic_System
-    static constexpr double equatorial_radius = 6378137.;
-    static constexpr double polar_radius = 6356752.3142;
-
     void measure(double dpn, double dpe, double & dlat, double & dlon);
-    inline double square(double a) {return a * a;}
     inline double deg_to_rad(double deg) {return deg * M_PI / 180.0;}
-    double earth_radius(double latitude);
-    void lla_to_ecef(double latitude, double longitude, double altitude, double &x, double &y, double &z);
 
   };
 }

--- a/include/rosflight_plugins/GPS_plugin.h
+++ b/include/rosflight_plugins/GPS_plugin.h
@@ -29,7 +29,9 @@
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
 
-#include <rosflight_msgs/GPS.h>
+#include <rosflight_msgs/GNSS.h>
+#include <sensor_msgs/NavSatFix.h>
+#include <geometry_msgs/TwistStamped.h>
 
 namespace rosflight_plugins 
 {
@@ -49,7 +51,9 @@ namespace rosflight_plugins
     std::string namespace_;
     ros::NodeHandle nh_;
     ros::NodeHandle nh_private_;
-    ros::Publisher GPS_pub_;
+    ros::Publisher GNSS_pub_;
+    ros::Publisher GNSS_fix_pub_;
+    ros::Publisher GNSS_vel_pub_;
 
     // Gazebo connections
     std::string link_name_;
@@ -64,10 +68,14 @@ namespace rosflight_plugins
     std::normal_distribution<double> standard_normal_distribution_;
 
     // Topic
-    std::string GPS_topic_;
+    std::string GNSS_topic_;
+    std::string GNSS_vel_topic_;
+    std::string GNSS_fix_topic_;
 
     // Message with static info prefilled
-    rosflight_msgs::GPS GPS_message_;
+    rosflight_msgs::GNSS GNSS_message_;
+    sensor_msgs::NavSatFix GNSS_fix_message_
+    geometry_msgs::TwistStamped GNSS_vel_message_;
 
     // params
     double pub_rate_;
@@ -93,7 +101,15 @@ namespace rosflight_plugins
 
     double sample_time_;
 
+    //Constants, from Wikipedia https://en.wikipedia.org/wiki/World_Geodetic_System
+    static constexpr double equatorial_radius = 6378137.;
+    static constexpr double polar_radius = 6356752.3142;
+
     void measure(double dpn, double dpe, double & dlat, double & dlon);
+    inline double square(double a) {return a * a;}
+    inline double deg_to_rad(double deg) {return deg * M_PI / 180.0}
+    double earth_radius(double latitude);
+    void lla_to_ecef(double latitude, double longitude, double altitude, double &x, double &y, double &z);
 
   };
 }

--- a/include/rosflight_plugins/gz_compat.h
+++ b/include/rosflight_plugins/gz_compat.h
@@ -39,6 +39,7 @@
 using GazeboVector = ignition::math::Vector3d;
 using GazeboPose = ignition::math::Pose3d;
 using GazeboQuaternion = ignition::math::Quaterniond;
+using GazeboAngle = ignition::math::Angle;
 
 #define GZ_COMPAT_GET_X(VECTOR) (VECTOR).X()
 #define GZ_COMPAT_GET_Y(VECTOR) (VECTOR).Y()
@@ -69,6 +70,7 @@ using GazeboQuaternion = ignition::math::Quaterniond;
 using GazeboVector = gazebo::math::Vector3;
 using GazeboPose = gazebo::math::Pose;
 using GazeboQuaternion = gazebo::math::Quaternion;
+using GazeboAngle = gazebo::math::Angle;
 
 #define GZ_COMPAT_GET_X(VECTOR) (VECTOR).x
 #define GZ_COMPAT_GET_Y(VECTOR) (VECTOR).y

--- a/include/rosflight_plugins/gz_compat.h
+++ b/include/rosflight_plugins/gz_compat.h
@@ -64,6 +64,7 @@ using GazeboAngle = ignition::math::Angle;
 #define GZ_COMPAT_DISCONNECT_WORLD_UPDATE_BEGIN(CONNECTION) (CONNECTION).reset()
 #define GZ_COMPAT_GET_GRAVITY(WORLD_PTR) (WORLD_PTR)->Gravity()
 #define GZ_COMPAT_GET_MASS(INERTIAL_PTR) (INERTIAL_PTR)->Mass()
+#define GZ_COMPAT_IGN_VECTOR(VECTOR) (VECTOR)
 
 #else //I.E. GAZEBO_MAJOR_VERSION < 8
 
@@ -95,6 +96,7 @@ using GazeboAngle = gazebo::math::Angle;
 #define GZ_COMPAT_DISCONNECT_WORLD_UPDATE_BEGIN(CONNECTION) gazebo::event::Events::DisconnectWorldUpdateBegin((CONNECTION))
 #define GZ_COMPAT_GET_GRAVITY(WORLD_PTR) (WORLD_PTR)->GetPhysicsEngine()->GetGravity()
 #define GZ_COMPAT_GET_MASS(INERTIAL_PTR) (INERTIAL_PTR)->GetMass()
+#define GZ_COMPAT_IGN_VECTOR(VECTOR) (VECTOR).Ign()
 
 #endif //GAZEBO_MAJOR_VERSION >= 8
 

--- a/src/GPS_plugin.cpp
+++ b/src/GPS_plugin.cpp
@@ -169,9 +169,9 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
       double altitude = initial_altitude_ + h;
 
       // Get Ground Speed
-      GazeboVector C_linear_velocity_W_C = GZ_COMPAT_GET_RELATIVE_LINEAR_VEL(link_);
-      double u = GZ_COMPAT_GET_X(C_linear_velocity_W_C);
-      double v = -GZ_COMPAT_GET_Y(C_linear_velocity_W_C);
+      ignition::math::Vector3d C_linear_velocity_W_C = GZ_COMPAT_IGN_VECTOR(GZ_COMPAT_GET_RELATIVE_LINEAR_VEL(link_));
+      double u = C_linear_velocity_W_C.X();
+      double v = -C_linear_velocity_W_C.Y();
       double Vg = sqrt(u*u + v*v);
       double sigma_vg = sqrt((u*u*north_stdev_*north_stdev_ + v*v*east_stdev_*east_stdev_)/(u*u + v*v));
       double ground_speed_error = sigma_vg*standard_normal_distribution_(random_generator_);
@@ -187,30 +187,30 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
       double ground_course_rad = chi + chi_error;
 
       //Calculate other values for messages
-      GazeboAngle lat_angle(deg_to_rad(initial_latitude_));
-      GazeboAngle lon_angle(deg_to_rad(initial_longitude_));
+      ignition::math::Angle lat_angle(deg_to_rad(initial_latitude_));
+      ignition::math::Angle lon_angle(deg_to_rad(initial_longitude_));
       gazebo::common::SphericalCoordinates spherical_coordinates(
           gazebo::common::SphericalCoordinates::SurfaceType::EARTH_WGS84, lat_angle, lon_angle, initial_altitude_,
-          GazeboAngle::Zero);
-      GazeboVector position_with_error(deg_to_rad(latitude_deg), deg_to_rad(longitude_deg), altitude);
-      GazeboVector velocity_with_error(ground_speed*cos(ground_course_rad), ground_speed*sin(ground_course_rad), 0);
-      GazeboVector ecef_position = spherical_coordinates.PositionTransform(position_with_error,
+          ignition::math::Angle::Zero);
+      ignition::math::Vector3d position_with_error(deg_to_rad(latitude_deg), deg_to_rad(longitude_deg), altitude);
+      ignition::math::Vector3d velocity_with_error(ground_speed*cos(ground_course_rad), ground_speed*sin(ground_course_rad), 0);
+      ignition::math::Vector3d ecef_position = spherical_coordinates.PositionTransform(position_with_error,
                                                                            gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL,
                                                                            gazebo::common::SphericalCoordinates::CoordinateType::ECEF);
-      GazeboVector ecef_velocity = spherical_coordinates.VelocityTransform(C_linear_velocity_W_C,
+      ignition::math::Vector3d ecef_velocity = spherical_coordinates.VelocityTransform(C_linear_velocity_W_C,
                                                                            gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
                                                                            gazebo::common::SphericalCoordinates::CoordinateType::ECEF);
 
       //Fill the GNSS message
-      gnss_message_.position[0] = GZ_COMPAT_GET_X(ecef_position);
-      gnss_message_.position[1] = GZ_COMPAT_GET_Y(ecef_position);
-      gnss_message_.position[2] = GZ_COMPAT_GET_Z(ecef_position);
+      gnss_message_.position[0] = ecef_position.X();
+      gnss_message_.position[1] = ecef_position.Y();
+      gnss_message_.position[2] = ecef_position.Z();
       gnss_message_.speed_accuracy = sigma_vg;
       gnss_message_.vertical_accuracy = alt_stdev_;
       gnss_message_.horizontal_accuracy = north_stdev_ > east_stdev_ ? north_stdev_ : east_stdev_;
-      gnss_message_.velocity[0] = GZ_COMPAT_GET_X(ecef_velocity);
-      gnss_message_.velocity[1] = GZ_COMPAT_GET_Y(ecef_velocity);
-      gnss_message_.velocity[2] = GZ_COMPAT_GET_Z(ecef_velocity);
+      gnss_message_.velocity[0] = ecef_velocity.X();
+      gnss_message_.velocity[1] = ecef_velocity.Y();
+      gnss_message_.velocity[2] = ecef_velocity.Z();
 
       //Fill the NavSatFix message
       gnss_fix_message_.latitude = latitude_deg;

--- a/src/GPS_plugin.cpp
+++ b/src/GPS_plugin.cpp
@@ -192,12 +192,12 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
       gazebo::common::SphericalCoordinates spherical_coordinates(
           gazebo::common::SphericalCoordinates::SurfaceType::EARTH_WGS84, lat_angle, lon_angle, initial_altitude_,
           ignition::math::Angle::Zero);
-      ignition::math::Vector3d position_with_error(deg_to_rad(latitude_deg), deg_to_rad(longitude_deg), altitude);
+      ignition::math::Vector3d lla_position_with_error(deg_to_rad(latitude_deg), deg_to_rad(longitude_deg), altitude);
       ignition::math::Vector3d velocity_with_error(ground_speed*cos(ground_course_rad), ground_speed*sin(ground_course_rad), 0);
-      ignition::math::Vector3d ecef_position = spherical_coordinates.PositionTransform(position_with_error,
+      ignition::math::Vector3d ecef_position = spherical_coordinates.PositionTransform(lla_position_with_error,
                                                                            gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL,
                                                                            gazebo::common::SphericalCoordinates::CoordinateType::ECEF);
-      ignition::math::Vector3d ecef_velocity = spherical_coordinates.VelocityTransform(C_linear_velocity_W_C,
+      ignition::math::Vector3d ecef_velocity = spherical_coordinates.VelocityTransform(velocity_with_error,
                                                                            gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
                                                                            gazebo::common::SphericalCoordinates::CoordinateType::ECEF);
 

--- a/src/GPS_plugin.cpp
+++ b/src/GPS_plugin.cpp
@@ -16,6 +16,7 @@
 
 #include "rosflight_plugins/GPS_plugin.h"
 #include "rosflight_plugins/gz_compat.h"
+#include <sensor_msgs/NavSatStatus.h>
 
 namespace rosflight_plugins
 {
@@ -79,7 +80,9 @@ void GPSPlugin::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _sdf)
   // load params from rosparam server
   int numSat;
   noise_on_ = nh_private_.param<bool>("noise_on", true);
-  GPS_topic_ = nh_private_.param<std::string>("topic", "gps");
+  GNSS_topic_ = nh_private_.param<std::string>("topic", "gps");
+  GNSS_fix_topic_ = nh_private_.param<std::string>("fix_topic", "navsat_compat/fix");
+  GNSS_vel_topic_ = nh_private_.param<std::string>("vel_topic", "navsat_compat/vel");
   north_stdev_ = nh_private_.param<double>("north_stdev", 0.21);
   east_stdev_ = nh_private_.param<double>("east_stdev", 0.21);
   alt_stdev_ = nh_private_.param<double>("alt_stdev", 0.40);
@@ -93,7 +96,10 @@ void GPSPlugin::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _sdf)
   numSat = nh_private_.param<int>("num_sats", 7);
 
   // ROS Publishers
-  GPS_pub_ = nh_.advertise<rosflight_msgs::GPS>(GPS_topic_, 1);
+  GNSS_pub_ = nh_.advertise<rosflight_msgs::GNSS>(GNSS_topic_, 1);
+  GNSS_fix_pub_ = nh_.advertise<sensor_msgs::NavSatFix>(GNSS_fix_topic_, 1);
+  GNSS_vel_pub_ = nh_.advertise<geometry_msgs::TwistStamped>(GNSS_vel_topic_, 1);
+
 
   // Calculate sample time from sensor update rate
   sample_time_ = 1.0/pub_rate_;
@@ -114,9 +120,10 @@ void GPSPlugin::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _sdf)
   }
 
   // Fill static members of GPS message.
-  GPS_message_.header.frame_id = link_name_;
-  GPS_message_.fix = true;
-  GPS_message_.NumSat = numSat;
+  //TODO update this to newest GNSS message standard
+  GNSS_message_.header.frame_id = link_name_;
+  GNSS_message_.fix = true;
+  GNSS_message_.NumSat = numSat;
 
   // initialize GPS error to zero
   north_GPS_error_ = 0.0;
@@ -153,11 +160,11 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
       // Convert meters to GPS angle
       double dlat, dlon;
       measure(pn, pe, dlat, dlon);
-      GPS_message_.latitude = initial_latitude_ + dlat * 180.0/M_PI;
-      GPS_message_.longitude = initial_longitude_ + dlon * 180.0/M_PI;
+      double latitude_deg = initial_latitude_ + dlat * 180.0/M_PI;
+      double longitude_deg = initial_longitude_ + dlon * 180.0/M_PI;
 
       // Altitude
-      GPS_message_.altitude = initial_altitude_ + h;
+      double altitude = initial_altitude_ + h;
 
       // Get Ground Speed
       GazeboVector C_linear_velocity_W_C = GZ_COMPAT_GET_RELATIVE_LINEAR_VEL(link_);
@@ -166,7 +173,7 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
       double Vg = sqrt(u*u + v*v);
       double sigma_vg = sqrt((u*u*north_stdev_*north_stdev_ + v*v*east_stdev_*east_stdev_)/(u*u + v*v));
       double ground_speed_error = sigma_vg*standard_normal_distribution_(random_generator_);
-      GPS_message_.speed = Vg + ground_speed_error;
+      double ground_speed = Vg + ground_speed_error;
 
       // Get Course Angle
       double psi = -GZ_COMPAT_GET_Z( GZ_COMPAT_GET_EULER( GZ_COMPAT_GET_ROT( W_pose_W_C)));
@@ -175,11 +182,33 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
       double chi = atan2(dy,dx);
       double sigma_chi = sqrt((dx*dx*north_stdev_*north_stdev_ + dy*dy*east_stdev_*east_stdev_)/((dx*dx+dy*dy)*(dx*dx+dy*dy)));
       double chi_error = sigma_chi*standard_normal_distribution_(random_generator_);
-      GPS_message_.ground_course = chi + chi_error;
+      double ground_course = chi + chi_error;
+
+      //Calculate other values for messages
+      double ecef_x, ecef_y, ecef_z;
+      lla_to_ecef(latitude_deg, longitude_deg, altitude, ecef_x, ecef_y, ecef_z);
+
+      //Fill the GNSS message
+      GNSS_message_.position[0] = ecef_x;
+      GNSS_message_.position[1] = ecef_y;
+      GNSS_message_.position[2] = ecef_z;
+      //TODO finish GNSS message fields
+
+      //Fill the NavSatFix message
+      GNSS_fix_message_.latitude = latitude_deg;
+      GNSS_fix_message_.longitude = longitude_deg;
+      GNSS_fix_message_.altitude = altitude;
+      GNSS_fix_message_.status.service = sensor_msgs::NavSatStatus::SERVICE_GPS;
+      GNSS_fix_message_.status.status = sensor_msgs::NavSatStatus::STATUS_FIX;
+      //TODO NavSatFix covariance
+
+      //Fill the TwistStamped
+      //TODO fill the TwistStamped
 
       // Publish
-      GPS_message_.header.stamp.fromSec(GZ_COMPAT_GET_SIM_TIME(world_).Double());
-      GPS_pub_.publish(GPS_message_);
+      //TODO publish all messages
+      GNSS_message_.header.stamp.fromSec(GZ_COMPAT_GET_SIM_TIME(world_).Double());
+      GNSS_pub_.publish(GNSS_message_);
 
       last_time_ = current_time;
   }
@@ -196,6 +225,28 @@ void GPSPlugin::measure(double dpn, double dpe, double& dlat, double& dlon)
   dlat = asin(dpn/R);
   dlon = asin(dpe/(R*cos(initial_latitude_*M_PI/180.0)));
 }
+//Distance from the center of earth to the surface at a particular latitude, using WGS84
+//latitude in degrees
+double GPSPlugin::earth_radius(double latitude)
+{
+  latitude = latitude / 180 * M_PI;
+  //Equation from https://en.wikipedia.org/wiki/Earth_radius#Location-dependent_radii
+  return sqrt((square(square(equatorial_radius) * cos(latitude)) + square(square(polar_radius) * sin(latitude))) /
+              (square(equatorial_radius*cos(latitude)) + square(polar_radius*latitude)));
+}
+//Angles in degrees, altitude in m above MSL per WGS84
+  void GPSPlugin::lla_to_ecef(double latitude, double longitude, double altitude, double &x, double &y, double &z) {
+    //Is there not a library function for this?
+    latitude = deg_to_rad(latitude);
+    longitude = deg_to_rad(longitude);
+    double geocentric_latitude = atan(
+        equatorial_radius / polar_radius * tan(latitude)); // possibly a more efficent way to do this
+    double radius = earth_radius(latitude);
+    z = radius * sin(geocentric_latitude);
+    double flat_radius = radius * cos(geocentric_latitude);
+    y = flat_radius * sin(longitude);
+    x = flat_radius * cos(longitude);
+  }
 
 
 GZ_REGISTER_MODEL_PLUGIN(GPSPlugin);

--- a/src/GPS_plugin.cpp
+++ b/src/GPS_plugin.cpp
@@ -195,7 +195,7 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
       GNSS_message_.position[0] = ecef_x;
       GNSS_message_.position[1] = ecef_y;
       GNSS_message_.position[2] = ecef_z;
-      //TODO GNSS message velocity and accuracies
+      //TODO GNSS message velocity
       GNSS_message_.speed_accuracy = sigma_vg;
       GNSS_message_.vertical_accuracy = alt_GPS_error_;
       GNSS_message_.horizontal_accuracy = north_GPS_error_ > east_GPS_error_ ? north_GPS_error_ : east_GPS_error_;
@@ -208,12 +208,17 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
 
       //Fill the TwistStamped
       //TODO fill the TwistStamped
+      GNSS_vel_message_.twist.linear.x = ground_speed * cos(ground_course);
+      GNSS_vel_message_.twist.linear.y = ground_speed * sin(ground_course);
+      GNSS_vel_message_.twist.linear.z = 0;
 
       // Publish
       //TODO publish all messages
       GNSS_message_.header.stamp.fromSec(GZ_COMPAT_GET_SIM_TIME(world_).Double());
       GNSS_vel_message_.header.stamp = GNSS_message_.header.stamp;
       GNSS_pub_.publish(GNSS_message_);
+      GNSS_fix_pub_.publish(GNSS_fix_message_);
+      GNSS_vel_pub_.publish(GNSS_vel_message_);
 
       last_time_ = current_time;
   }


### PR DESCRIPTION
This adds compatibility with the new ROSFlight GNSS format. The plugin now outputs ROSFlight GNSS messages, NavSatFix messages, and TwistStamped messages. This emulates GNSS passthrough via ROSFlight and is compatible with the standard ROS NMEA navsat driver.
This has been tested in ROS Melodic, but should maintain compatibility with ROS Kinetic.