### PR TITLE
Updated GPS plugin error model calculation.

### DIFF
--- a/src/GPS_plugin.cpp
+++ b/src/GPS_plugin.cpp
@@ -147,13 +147,13 @@ void GPSPlugin::OnUpdate(const gazebo::common::UpdateInfo& _info)
 
       // Add noise per Gauss-Markov Process (p. 139 UAV Book)
       double noise = north_stdev_*standard_normal_distribution_(random_generator_);
-      north_GPS_error_ = exp(-1.0*north_k_GPS_*sample_time_)*north_GPS_error_ + noise;
+      north_GPS_error_ = exp(-1.0*north_k_GPS_*sample_time_)*north_GPS_error_ + noise*sample_time_;
 
       noise = east_stdev_*standard_normal_distribution_(random_generator_);
-      east_GPS_error_ = exp(-1.0*east_k_GPS_*sample_time_)*east_GPS_error_ + noise;
+      east_GPS_error_ = exp(-1.0*east_k_GPS_*sample_time_)*east_GPS_error_ + noise*sample_time_;
 
       noise = alt_stdev_*standard_normal_distribution_(random_generator_);
-      alt_GPS_error_ = exp(-1.0*alt_k_GPS_*sample_time_)*alt_GPS_error_ + noise;
+      alt_GPS_error_ = exp(-1.0*alt_k_GPS_*sample_time_)*alt_GPS_error_ + noise*sample_time_;
 
       // Find NED position in meters
       GazeboPose W_pose_W_C = GZ_COMPAT_GET_WORLD_COG_POSE(link_);


### PR DESCRIPTION
After conferring with Dr. Beard, we found that the GPS error model approximation from the UAV book was incorrect, which is why using the gazebo simulation required a really small gps st_dev to give any good results with quadrotor flight. It was an easy fix, the notes are attached.
![Image](https://user-images.githubusercontent.com/37413999/83817151-43ff0580-a681-11ea-8626-c68e094589cc.jpg)

